### PR TITLE
Fix OMERO 4.4. version number

### DIFF
--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -84,6 +84,6 @@ index a00ac93..9bd4b05 100644
              </try>
              <catch>
 -                <echo>UNKNOWN-ice${versions.ice_lib}</echo>
-+                <echo>4.4.0-RC2-ice${versions.ice_lib}</echo>
++                <echo>4.4.0-ice${versions.ice_lib}</echo>
              </catch>
          </trycatch>


### PR DESCRIPTION
Tested OMERO 4.4.0 installation with homebrew & zeroc-ice33. Passed.
Minor point: version number still set to 4.4.0-RC2, addressed by this PR.

Could we set this full installation script as a job run by hudson?
