### PR TITLE
Add Homebrew formula for Bio-Formats

### DIFF
--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -4,8 +4,8 @@ class Bioformats < Formula
   homepage 'https://www.openmicroscopy.org'
 
   head 'https://github.com/openmicroscopy/bioformats.git', :branch => 'develop'
-  url 'https://github.com/openmicroscopy/bioformats.git', :tag => 'v4.4.2'
-  version '4.4.2'
+  url 'https://github.com/openmicroscopy/bioformats.git', :tag => 'v4.4.4'
+  version '4.4.4'
 
   def options
     [


### PR DESCRIPTION
- To test the formula, use:

```
brew tap sbesson/alt
brew install bioformats
```
- Command-line utilities should be available, e.g `formatlist`
- OME tools is built by default but is optional

```
brew install bioformats --without-ome-tools
```
