### PR TITLE
scc.rb formula

### DIFF
--- a/Formula/scc.rb
+++ b/Formula/scc.rb
@@ -2,11 +2,17 @@ require 'formula'
 
 class Scc < Formula
   homepage 'https://github.com/snoopycrimecop/snoopycrimecop'
-
   head 'https://github.com/snoopycrimecop/snoopycrimecop.git', :branch => 'master'
+  url 'https://github.com/snoopycrimecop/snoopycrimecop/archive/0.1.0.tar.gz'
+  version '0.1.0'
+  sha1 '08c6349db028be5287eb7d410c697a67ada6ad38'
 
   def install
     File.rename("scc.py", "scc")
     bin.install("scc")
+  end
+
+  def test
+    system "scc -h"
   end
 end


### PR DESCRIPTION
With this formula, the following will install the latest scc tag:

```
brew untap ome/alt
brew tap ome/alt
brew install scc
```

and this will install from git:

```
brew untap ome/alt
brew tap ome/alt
brew install --HEAD scc
```

(Until this PR is accepted, this won't work. It'll be necessary to checkout my scc-formula branch directly)

/cc @sbesson
