### PR TITLE
Use Github tar.gz instead of cloning the repo for the stable B-F

### DIFF
--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -6,6 +6,7 @@ class Bioformats < Formula
   head 'https://github.com/openmicroscopy/bioformats.git', :branch => 'dev_4_4'
   url 'https://github.com/openmicroscopy/bioformats/archive/v4.4.6.tar.gz'
   version '4.4.6'
+  sha1 '8678b424d3ad3b7f8442bc6f365e45a5b9fedcaf'
 
   option 'without-ome-tools', 'Do not build OME Tools.'
 


### PR DESCRIPTION
This change should speed up the installation time of Bio-Formats using `brew install bioformats`. Cloning the repository only makes sense for `omero.rb` since GH archives don't include the submodules.

Once this change is merged, any veto to opening a PR against the main homebrew repository to register bioformats.rb?

/cc @melissalinkert
