### PR TITLE
Fix ZeroC library linking when using `brew install --HEAD omero`

### DIFF
--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -59,11 +59,11 @@ class Omero < Formula
     python = lib+"python"
 
     if build.with? 'with-ice34'
-      zeroc = Formula.factory('ome/alt/ice')
+      zeroc_prefix = Formula.factory('ome/alt/ice').opt_prefix
     else
-      zeroc = Formula.factory('zeroc-ice33')
+      zeroc_prefix = Formula.factory('zeroc-ice33').opt_prefix
     end
-    zp = zeroc.prefix+"python"
+    zp = zeroc_prefix+"python"
     zp.cd { Dir["*"].each {|p| ln_sf zp + p, python + File.basename(p) }}
 
   end


### PR DESCRIPTION
Error from [OMERO-homebrew-stable#137](http://hudson.openmicroscopy.org.uk/view/2.%20Stable/job/OMERO-homebrew-stable/137/OSX=10.7.5/console)

```
++ bin/brew install omero --HEAD
==> Installing omero dependency: autoconf
...
==> Checking out branch dev_4_4
==> ./build.py -Dice.home=/usr/local build-default
Error: No such file or directory - /usr/local/Cellar/zeroc-ice33/HEAD/python
```
