### PR TITLE
Add genshi dependency for develop version of OMERO formula

### DIFF
--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -23,6 +23,7 @@ class Omero < Formula
   depends_on 'ome/alt/ice' if build.with? 'with-ice34'
   depends_on 'zeroc-ice33' unless build.with? 'with-ice34'
   depends_on 'mplayer' => :recommended
+  depends_on 'genshi' => :python if build.devel?
 
   def install
     # Create config file to specify dist.dir (see #9203)


### PR DESCRIPTION
Similarly to #27, if building the develop branch of OMERO using `brew install omero --devel`, we want an informative error message checking and asking to install `genshi` first.
