### PR TITLE
Add support for brewed Python in Ice 3.3 formula

### DIFF
--- a/Formula/zeroc-ice33.rb
+++ b/Formula/zeroc-ice33.rb
@@ -6,7 +6,7 @@ class ZerocIce33 < Formula
   url 'https://github.com/joshmoore/zeroc-ice/archive/v.3.3.1-clang.tar.gz'
   sha1 'd6bac03c32a27fe1414c519d3e6e08a2156232b6'
 
-  head 'http://github.com/joshmoore/zeroc-ice.git', :branch => 'Ice-3.3.1'
+  head 'https://github.com/joshmoore/zeroc-ice.git', :branch => 'Ice-3.3.1'
 
   depends_on 'mcpp'
   depends_on 'berkeley-db46' => '--without-java'


### PR DESCRIPTION
With this PR locally merged, the three following scenarios should be testable:
- System-wide Python
  
  ```
  $ brew install zeroc-ice33
  $ PYTHONPATH=$(brew --prefix zeroc-ice33)/python /usr/bin/python -c 'import Ice'
  ```
- Brewed non-framework Python
  
  ```
  $ brew install python
  $ brew install zeroc-ice33
  $ PYTHONPATH=$(brew --prefix zeroc-ice33)/python /usr/local/bin/python -c 'import Ice'
  ```
  
  The following command
  
  ```
  $ PYTHONPATH=$(brew --prefix zeroc-ice33)/python /usr/bin/python -c 'import Ice'
  ```
  
  should fail since IcePy is build against the brewed Python
- Brewed framework Python
  
  ```
  $ brew install python --framework
  $ brew install zeroc-ice33
  $ PYTHONPATH=$(brew --prefix zeroc-ice33)/python /usr/local/bin/python -c 'importIce'
  ```
  
  Also
  
  ```
  $ PYTHONPATH=$(brew --prefix zeroc-ice33)/python /usr/local/bin/python -c 'import Ice'
  ```
  
  should fail since IcePy is build against the brewed framework Python
