### PR TITLE
Declare Python dependency in OMERO and Bio-Formats formulas

### DIFF
--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -13,6 +13,7 @@ class Bioformats < Formula
     version '5.0.0-DEV'
   end
 
+  depends_on :python if build.devel?
   depends_on 'genshi' => :python if build.devel?
   option 'without-ome-tools', 'Do not build OME Tools.'
 

--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -15,6 +15,7 @@ class Omero < Formula
   option 'with-cpp', 'Build OmeroCpp libraries.'
   option 'with-ice34', 'Use Ice 3.4.'
 
+  depends_on :python
   depends_on 'ccache' => :recommended
   depends_on 'pkg-config' => :build
   depends_on 'hdf5'


### PR DESCRIPTION
Allow to use Genshi installed as a brewed Python module during the formula
installation
