### PR TITLE
Add support for brewed Python and Ice 3.4 formula

### DIFF
--- a/Formula/zeroc-ice34.rb
+++ b/Formula/zeroc-ice34.rb
@@ -17,10 +17,6 @@ class ZerocIce34 < Formula
      :p1 =>"https://raw.github.com/gist/1619052/5be2a4bed2d4f1cf41ce9b95141941a252adaaa2/Ice-3.4.2-db5.patch"}
   end
 
-  def which_python
-    "python" + `python -c 'import sys;print(sys.version[:3])'`.strip
-  end
-
   option 'doc', 'Install documentation'
   option 'demo', 'Build demos'
   option 'with-java', 'Build Java library'


### PR DESCRIPTION
Similar changes as #33. 
To be tested in a OMERO-homebrew-\* job with `--with-ice34` option on.
