### PR TITLE
Travis: formula installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: objective-c
 env:
   - FORMULA=bioformats BREW_OPTS=
   - FORMULA=bioformats BREW_OPTS=--devel
+  - FORMULA=zeroc-ice33 BREW_OPTS=
+  - FORMULA=zeroc-ice34 BREW_OPTS=
 before_script:
     - sudo easy_install pip
     - sudo pip install genshi
     - brew update
+    - brew tap ome/alt
     - brew audit Formula/*.rb
 script: brew install Formula/$FORMULA.rb $BREW_OPTS


### PR DESCRIPTION
Test several formulas installation as part of the Travis build.

This PR adds `brew install` steps to the Travis build, namely:
- Bio-Formats (last stable release and last develop release with `--devel`)
- Ice 3.3 and 3.4 formulas.

OMERO was another candidate for inclusion as part of this PR but the build step errors while exceeding the 10 minutes timeout enforced by Travis. I suggest keeping the OMERO installation on our CI for now.
