### PR TITLE
Set Ice 3.4 as the default Ice version in the OMERO formula

### DIFF
--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -13,7 +13,7 @@ class Omero < Formula
   end
 
   option 'with-cpp', 'Build OmeroCpp libraries.'
-  option 'with-ice34', 'Use Ice 3.4.'
+  option 'with-ice33', 'Use Ice 3.3.'
 
   depends_on :python
   depends_on :fortran
@@ -21,8 +21,8 @@ class Omero < Formula
   depends_on 'pkg-config' => :build
   depends_on 'hdf5'
   depends_on 'jpeg'
-  depends_on 'zeroc-ice34' => 'with-python' if build.with? 'ice34'
-  depends_on 'zeroc-ice33' unless build.with? 'ice34'
+  depends_on 'zeroc-ice34' => 'with-python' unless build.with? 'ice33'
+  depends_on 'zeroc-ice33' if build.with? 'ice33'
   depends_on 'mplayer' => :recommended
   depends_on 'genshi' => :python if build.devel?
 
@@ -70,7 +70,7 @@ class Omero < Formula
   end
 
   def ice_prefix
-    if build.with? 'ice34'
+    unless build.with? 'ice33'
       Formula.factory('zeroc-ice34').opt_prefix
     else
       Formula.factory('zeroc-ice33').opt_prefix


### PR DESCRIPTION
With this commit, `brew install omero` now installs Ice 3.4 by default. To draw back to an Ice 3.3 installation, use the `--with-ice33` option.

To test this PR;
- check the Travis status is green
- check the OMERO-homebrew-stable and OMERO-homebrew-develop jobs are passing with this PR merged in

Once this PR is merged in, we should update the Homebrew documentation page to reflect the change in the default installation.

/cc @rleigh-dundee, @bpindelski, @jburel, @hflynn
