### PR TITLE
Fix patch link in zeroc-ice34 formula

### DIFF
--- a/Formula/zeroc-ice34.rb
+++ b/Formula/zeroc-ice34.rb
@@ -13,7 +13,7 @@ class ZerocIce34 < Formula
 
   def patches
     # Patch for Ice-3.4.2 to work with Berkely DB 5.X rather than 4.X
-    {:p0 => "http://www.zeroc.com/forums/attachments/patches/973d1330948195-patch-compiling-ice-clang-gcc4-7-ice_for_clang_2012-03-05.txt",
+    {:p0 => "http://www.zeroc.com/forums/attachment.php?attachmentid=973&d=1330948195",
      :p1 =>"https://raw.github.com/gist/1619052/5be2a4bed2d4f1cf41ce9b95141941a252adaaa2/Ice-3.4.2-db5.patch"}
   end
 


### PR DESCRIPTION
This PR should
- have a green Travis status for all the tested components
- turn [OMERO-homebrew-develop](http://hudson.openmicroscopy.org.uk/job/OMERO-homebrew-develop/) and [OMERO-homebrew-stable](http://hudson.openmicroscopy.org.uk/job/OMERO-homebrew-stable/) green by fixing the default zeroc-ice34 formula.

More generally, do we want to find an alternate location for these patches if the forum URL evolves again?
