### PR TITLE
Fix PYTHON_HOME definition in old Ice formulas

### DIFF
--- a/Formula/zeroc-ice33.rb
+++ b/Formula/zeroc-ice33.rb
@@ -26,7 +26,7 @@ class ZerocIce33 < Formula
     system "cd cpp && make MCPP_HOME=#{mcpp.prefix} DB_HOME=#{bdb46.prefix} OPTIMIZE=yes prefix=#{prefix} embedded_runpath_prefix=#{prefix} install"
 
     ENV["ICE_HOME"] = "#{prefix}"
-    ENV["PYTHON_HOME"] = python.prefix if python.brewed? and python.framework?
+    ENV["PYTHON_HOME"] = Pathname.new `python-config --prefix`.chomp
     system "cd rb && make OPTIMIZE=yes prefix=#{prefix} embedded_runpath_prefix=#{prefix} install"
     system "cd py && make OPTIMIZE=yes prefix=#{prefix} embedded_runpath_prefix=#{prefix} install"
 

--- a/Formula/zeroc-ice34.rb
+++ b/Formula/zeroc-ice34.rb
@@ -66,7 +66,7 @@ class ZerocIce34 < Formula
         s.gsub! "/opt/Ice-$(VERSION_MAJOR).$(VERSION_MINOR)", prefix
       end
 
-      ENV["PYTHON_HOME"] = python.prefix if python.brewed? and python.framework?
+      ENV["PYTHON_HOME"] = Pathname.new `python-config --prefix`.chomp
       Dir.chdir "py" do
         system "make"
         system "make install"


### PR DESCRIPTION
This should fix the failing 3.3 and 3.4 components of the http://ci.openmicroscopy.org/job/OME-5.0-merge-homebrew/ job.
