### PR TITLE
Bump OMERO and Bio-Formats versions to 5.0.2

### DIFF
--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Bioformats < Formula
   homepage 'http://www.openmicroscopy.org/site/products/bio-formats'
 
-  url 'http://downloads.openmicroscopy.org/bio-formats/5.0.1/artifacts/bioformats-5.0.1.zip'
-  sha1 '32e1a3ea1d755c0fd6c93bfbb1f3d98d228725b8'
+  url 'http://downloads.openmicroscopy.org/bio-formats/5.0.2/artifacts/bioformats-5.0.2.zip'
+  sha1 '2b286741dec8a7b8ec4244f60aef410c07973194'
 
   depends_on :python
   depends_on 'genshi' => :python

--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Omero < Formula
   homepage 'http://www.openmicroscopy.org/site/products/omero'
 
-  url 'http://downloads.openmicroscopy.org/omero/5.0.1/artifacts/openmicroscopy-5.0.1.zip'
-  sha1 '8c5fe6032953db97a42ad35d4fb06e7f9516670d'
+  url 'http://downloads.openmicroscopy.org/omero/5.0.2/artifacts/openmicroscopy-5.0.2.zip'
+  sha1 '4b051a3c63621e5fcc995970567a5e2ca5914572'
 
   option 'with-cpp', 'Build OmeroCpp libraries.'
   option 'with-ice33', 'Use Ice 3.3.'
@@ -101,8 +101,8 @@ index 0000000..ff40ea9
 @@ -0,0 +1,7 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<project name="gitversion" basedir=".">
-+        <property name="release.version" value="5.0.1"/>
-+        <property name="release.shortversion" value="5.0.1"/>
-+        <property name="vcs.revision" value="b5a33fe"/>
-+        <property name="vcs.date" value="Thu Apr 3 14:00:09 2014 -0500"/>
++        <property name="release.version" value="5.0.2"/>
++        <property name="release.shortversion" value="5.0.2"/>
++        <property name="vcs.revision" value="0c4215a"/>
++        <property name="vcs.date" value="Tue May 27 13:19:17 2014 -0500"/>
 +</project>


### PR DESCRIPTION
To be tested by http://ci.openmicroscopy.org/job/OME-5.0-merge-homebrew/?.

Check that:
- [x] Bio-Formats and OMERO build (for all versions of Ice)
- [x] the output of `showinf` is correct (vcs revision, date)
- [x] the log of the fake import is correct (version numbers, revision numbers...)
