### PR TITLE
Add ant as a build dependency of the Bio-Formats formula

### DIFF
--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -6,7 +6,8 @@ class Bioformats < Formula
   url 'http://downloads.openmicroscopy.org/bio-formats/5.0.2/artifacts/bioformats-5.0.2.zip'
   sha1 '2b286741dec8a7b8ec4244f60aef410c07973194'
 
-  depends_on :python
+  depends_on :python => :build
+  depends_on :ant => :build
   depends_on 'genshi' => :python
 
   def install


### PR DESCRIPTION
This should fix OME-5.0-merge-homebrew with a clean box without ant installed

/cc @rleigh-dundee @kennethgillen 
