### PR TITLE
Add ant as build dependency for old Bio-Formats 4.4 formula

### DIFF
--- a/Formula/bioformats44.rb
+++ b/Formula/bioformats44.rb
@@ -8,6 +8,8 @@ class Bioformats44 < Formula
 
   option 'without-ome-tools', 'Do not build OME Tools.'
 
+  depends_on :ant => :build
+
   def patches
     # build generates a version number with 'git show' command
     # but Homebrew build runs in temp copy created via git checkout-index,


### PR DESCRIPTION
Same as #60. Check the output of the next `OME-4.4-merge-homebrew` build
