### PR TITLE
Add an optional dependency on nginx for OMERO

### DIFF
--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -21,6 +21,7 @@ class Omero < Formula
   depends_on 'zeroc-ice33' if build.with? 'ice33'
   depends_on 'mplayer' => :recommended
   depends_on 'genshi' => :python
+  depends_on 'nginx' => :optional
 
   def install
     # Create config file to specify dist.dir (see #9203)


### PR DESCRIPTION
With this PR, `nginx` should be installable with the OMERO formula with:

```
brew install omero --with-nginx
brew install omero --only-dependencies --with-nginx
```

/cc @kennethgillen 
