### PR TITLE
Travis only dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ before_script:
     - brew tap homebrew/science
     - brew audit Formula/*.rb
 script:
-    - if [[ $FORMULA == 'omero' ]]; then pip install Genshi; fi
+    - if [[ $FORMULA == 'omero' ]]; then sudo pip install Genshi; fi
     - VERBOSE=1 brew install Formula/$FORMULA.rb $BREW_OPTS
     - if [[ $FORMULA != 'omero' ]]; then brew test Formula/$FORMULA.rb; fi


### PR DESCRIPTION
Adds a testing step for the `brew install --only-dependencies` command documented in https://github.com/openmicroscopy/ome-documentation/pull/960
