### PR TITLE
Drop Genshi from the 5.1.x formulas

### DIFF
--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -8,7 +8,6 @@ class Bioformats < Formula
 
   depends_on :python => :build
   depends_on :ant => :build
-  depends_on 'genshi' => :python
 
   def install
     # Build libraries

--- a/Formula/bioformats51.rb
+++ b/Formula/bioformats51.rb
@@ -8,7 +8,6 @@ class Bioformats51 < Formula
 
   depends_on :python => :build
   depends_on :ant => :build
-  depends_on 'genshi' => :python
 
   def install
     # Build libraries

--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -18,7 +18,6 @@ class Omero < Formula
   depends_on 'ice' => 'with-python' if build.without? 'ice34'
   depends_on 'zeroc-ice34' => 'with-python' if build.with? 'ice34'
   depends_on 'mplayer' => :recommended
-  depends_on 'genshi' => :python
   depends_on 'nginx' => :optional
 
   def install

--- a/Formula/omero51.rb
+++ b/Formula/omero51.rb
@@ -18,7 +18,6 @@ class Omero51 < Formula
   depends_on 'ice' => 'with-python' if build.without? 'ice34'
   depends_on 'zeroc-ice34' => 'with-python' if build.with? 'ice34'
   depends_on 'mplayer' => :recommended
-  depends_on 'genshi' => :python
   depends_on 'nginx' => :optional
 
   def install


### PR DESCRIPTION
With 5.1.0 we should not need the Genshi dependency in the formula anymore as it is included in the release source.