### PR TITLE
Bump formulas to version 5.1.2

### DIFF
--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Bioformats < Formula
   homepage 'http://www.openmicroscopy.org/site/products/bio-formats'
 
-  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.1/artifacts/bioformats-5.1.1.zip'
-  sha1 'dd4dedc6d0cd7b0493107c27ec928d69c49ad58a'
+  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.2/artifacts/bioformats-5.1.2.zip'
+  sha1 'b39f78ef63beb599633d34c1778239a5bfed9a88'
 
   depends_on :python => :build
   depends_on :ant => :build

--- a/Formula/bioformats51.rb
+++ b/Formula/bioformats51.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Bioformats51 < Formula
   homepage 'http://www.openmicroscopy.org/site/products/bio-formats'
 
-  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.1/artifacts/bioformats-5.1.1.zip'
-  sha1 'dd4dedc6d0cd7b0493107c27ec928d69c49ad58a'
+  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.2/artifacts/bioformats-5.1.2.zip'
+  sha1 'b39f78ef63beb599633d34c1778239a5bfed9a88'
 
   depends_on :python => :build
   depends_on :ant => :build

--- a/Formula/omero.rb
+++ b/Formula/omero.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Omero < Formula
   homepage 'http://www.openmicroscopy.org/site/products/omero'
 
-  url 'http://downloads.openmicroscopy.org/omero/5.1.1/artifacts/openmicroscopy-5.1.1.zip'
-  sha1 '847bb4ba164408eb02ecbd8a2d22614d08eafb0b'
+  url 'http://downloads.openmicroscopy.org/omero/5.1.2/artifacts/openmicroscopy-5.1.2.zip'
+  sha1 '38ac26e0b0e7ef9d40442cf5a167fc85e5b99ee1'
 
   option 'with-cpp', 'Build OmeroCpp libraries.'
   option 'with-ice34', 'Use Ice 3.4.'

--- a/Formula/omero51.rb
+++ b/Formula/omero51.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Omero51 < Formula
   homepage 'http://www.openmicroscopy.org/site/products/omero'
 
-  url 'http://downloads.openmicroscopy.org/omero/5.1.1/artifacts/openmicroscopy-5.1.1.zip'
-  sha1 '847bb4ba164408eb02ecbd8a2d22614d08eafb0b'
+  url 'http://downloads.openmicroscopy.org/omero/5.1.2/artifacts/openmicroscopy-5.1.2.zip'
+  sha1 '38ac26e0b0e7ef9d40442cf5a167fc85e5b99ee1'
 
   option 'with-cpp', 'Build OmeroCpp libraries.'
   option 'with-ice34', 'Use Ice 3.4.'


### PR DESCRIPTION
To test this PR, check the next run of https://ci.openmicroscopy.org/job/OME-5.1-merge-homebrew/ is green and builds the 5.1.2 versions of OMERO/Bio-Formats.