### PR TITLE
Skip zeroc-ice34 testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: objective-c
 matrix:
   fast_finish: true
 env:
-  - FORMULA=zeroc-ice34 BREW_OPTS=
-  - FORMULA=zeroc-ice34 BREW_OPTS=--with-python
-  - FORMULA=zeroc-ice34 BREW_OPTS=--with-java
   - FORMULA=zeroc-ice35 BREW_OPTS=--with-python
   - FORMULA=omero BREW_OPTS=--only-dependencies
 before_script:


### PR DESCRIPTION
This formula is no longer active on the stable OMERO line. This commit removes
it from the Travis testing matrix to reduce our maintenance burden.