### PR TITLE
Bump Bio-Formats to version 5.1.10

### DIFF
--- a/Formula/bioformats51.rb
+++ b/Formula/bioformats51.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Bioformats51 < Formula
   homepage 'http://www.openmicroscopy.org/site/products/bio-formats'
 
-  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.9/artifacts/bioformats-5.1.10.zip'
+  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.10/artifacts/bioformats-5.1.10.zip'
   sha256 '4bae68c8e99c6df8dae699f331b1554e6be040b34e05ca47ae93bd77841b8bc2'
 
   depends_on :python => :build

--- a/Formula/bioformats51.rb
+++ b/Formula/bioformats51.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Bioformats51 < Formula
   homepage 'http://www.openmicroscopy.org/site/products/bio-formats'
 
-  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.9/artifacts/bioformats-5.1.9.zip'
-  sha256 'dd105be12a9616e4b4b44988db36006b96710b88b39cb0951ca92eff704a230a'
+  url 'http://downloads.openmicroscopy.org/bio-formats/5.1.9/artifacts/bioformats-5.1.10.zip'
+  sha256 '4bae68c8e99c6df8dae699f331b1554e6be040b34e05ca47ae93bd77841b8bc2'
 
   depends_on :python => :build
   depends_on :ant => :build


### PR DESCRIPTION
To be tested via https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-homebrew/.