### PR TITLE
Bio-Formats 5.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_script:
     - brew tap homebrew/science
     - brew tap ome/alt file://$(pwd)
     - brew audit Formula/*.rb
-    - brew audit --strict Formula/bioformats52.rb
 script:
     - VERBOSE=1 brew install $FORMULA $BREW_OPTS
     - if [[ $FORMULA != 'omero' ]]; then brew test $FORMULA; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
     - brew tap homebrew/science
     - brew tap ome/alt file://$(pwd)
     - brew audit Formula/*.rb
+    - brew audit --strict Formula/bioformats52.rb
 script:
     - VERBOSE=1 brew install $FORMULA $BREW_OPTS
     - if [[ $FORMULA != 'omero' ]]; then brew test $FORMULA; fi

--- a/Formula/bioformats52.rb
+++ b/Formula/bioformats52.rb
@@ -1,8 +1,8 @@
 class Bioformats52 < Formula
   desc "Library for reading proprietary image file formats"
   homepage "http://www.openmicroscopy.org/site/products/bio-formats"
-  url "http://downloads.openmicroscopy.org/bio-formats/5.2.2/artifacts/bioformats-5.2.2.zip"
-  sha256 "fbc01f12dd3d5d08f5dcf46fec7476a30c219fcd38937720d32c2c4a6625625d"
+  url "http://downloads.openmicroscopy.org/bio-formats/5.2.3/artifacts/bioformats-5.2.3.zip"
+  sha256 "fea88359ee25daf2b7b057290aebc29d128edbe36810958d3e331926da5c3482"
 
   depends_on "python" => :build
   depends_on "ant" => :build

--- a/Formula/bioformats52.rb
+++ b/Formula/bioformats52.rb
@@ -4,8 +4,8 @@ class Bioformats52 < Formula
   url "http://downloads.openmicroscopy.org/bio-formats/5.2.2/artifacts/bioformats-5.2.2.zip"
   sha256 "fbc01f12dd3d5d08f5dcf46fec7476a30c219fcd38937720d32c2c4a6625625d"
 
-  depends_on :python => :build
-  depends_on :ant => :build
+  depends_on "python" => :build
+  depends_on "ant" => :build
 
   def install
     # Build libraries
@@ -20,9 +20,13 @@ class Bioformats52 < Formula
 
     # Copy command line-tools
     libexec.install Dir["tools/*"]
-    bin.install_symlink libexec/"showinf"
+
+    %w[bfconvert domainlist formatlist ijview mkfake omeul showinf tiffcomment xmlindent xmlvalid].each do |fn|
+      bin.install_symlink libexec/fn
+    end
   end
   test do
     system "showinf", "-version"
+    system "bfconvert", "-version"
   end
 end

--- a/Formula/bioformats52.rb
+++ b/Formula/bioformats52.rb
@@ -16,10 +16,11 @@ class Bioformats52 < Formula
     rm Dir["tools/*.bat"]
 
     # Copy artifacts
-    bin.install "artifacts/bioformats_package.jar"
+    libexec.install "artifacts/bioformats_package.jar"
 
     # Copy command line-tools
-    bin.install Dir["tools/*"]
+    libexec.install Dir["tools/*"]
+    bin.install_symlink libexec/"showinf"
   end
   test do
     system "showinf", "-version"

--- a/Formula/bioformats52.rb
+++ b/Formula/bioformats52.rb
@@ -1,17 +1,15 @@
-require 'formula'
-
 class Bioformats52 < Formula
-  homepage 'http://www.openmicroscopy.org/site/products/bio-formats'
-
-  url 'http://downloads.openmicroscopy.org/bio-formats/5.2.2/artifacts/bioformats-5.2.2.zip'
-  sha256 'fbc01f12dd3d5d08f5dcf46fec7476a30c219fcd38937720d32c2c4a6625625d'
+  desc "Library for reading proprietary image file formats"
+  homepage "http://www.openmicroscopy.org/site/products/bio-formats"
+  url "http://downloads.openmicroscopy.org/bio-formats/5.2.2/artifacts/bioformats-5.2.2.zip"
+  sha256 "fbc01f12dd3d5d08f5dcf46fec7476a30c219fcd38937720d32c2c4a6625625d"
 
   depends_on :python => :build
   depends_on :ant => :build
 
   def install
     # Build libraries
-    args = ["ant", "clean" ,"tools", "utils"]
+    args = ["ant", "clean", "tools", "utils"]
     system *args
 
     # Remove Windows files


### PR DESCRIPTION
See https://trello.com/c/mlfp1laZ/27-open-a-pr-to-bump-the-homebrew-formula and https://trello.com/c/5QtSmar5/52-homebrew-formula-symlinks

This PR:
- bumps the version of Bio-FOrmats to 5.2.3 with the correct shasum
- symlinks the command-line tools executables to `bin` from `libexec` (preventing `bf.sh` and `bioformats_package.jar` to be on the PATH)
- enables strict auditing of the Bio-Formats formula in `.travis.yml` and make necessary updates