### PR TITLE
Travis fix: only build OMERO dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ before_script:
     - brew tap homebrew/science
     - brew tap ome/alt file://$(pwd)
     - brew audit Formula/*.rb
-script:
-    - VERBOSE=1 brew install omero --only-dependencies
+script: brew install omero --only-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: objective-c
-matrix:
-  fast_finish: true
-env:
-  - FORMULA=zeroc-ice35 BREW_OPTS=--with-python
-  - FORMULA=omero BREW_OPTS=--only-dependencies
+env: VERBOSE=1
 before_script:
     - brew update
     - brew tap homebrew/science
     - brew tap ome/alt file://$(pwd)
     - brew audit Formula/*.rb
 script:
-    - VERBOSE=1 brew install $FORMULA $BREW_OPTS
-    - if [[ $FORMULA != 'omero' ]]; then brew test $FORMULA; fi
+    - VERBOSE=1 brew install omero --only-dependencies


### PR DESCRIPTION
As shown by the recent Travis builds (https://github.com/ome/homebrew-alt/pull/120, https://github.com/ome/homebrew-alt/pull/122), the `zeroc-ice35` formula no longer builds in the OS X environment provided by Travis.

As we are moved to Ice 3.6 as the default Ice version in OMERO 5.3, this PR restores Travis by simplifying the matrix and only testing the OMERO dependencies. /cc @jburel 
