### PR TITLE
Release 5.2.8 ice36

### DIFF
--- a/Formula/omero52.rb
+++ b/Formula/omero52.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Omero52 < Formula
   homepage 'http://www.openmicroscopy.org/site/products/omero'
 
-  url 'http://downloads.openmicroscopy.org/omero/5.2.7/artifacts/openmicroscopy-5.2.7.zip'
-  sha256 'ad1b52a8337440ce5329e8dd784d51d324283aee20c609106f5aab60223c1561'
+  url 'http://downloads.openmicroscopy.org/omero/5.2.8/artifacts/openmicroscopy-5.2.8.zip'
+  sha256 '81f0d29e6ec2f26cb6e4bba6c0a9e62c18567b9a3cd8050ac11a4b4fc4e7ed7e'
 
   option 'with-cpp', 'Build OmeroCpp libraries.'
 

--- a/Formula/omero52.rb
+++ b/Formula/omero52.rb
@@ -7,6 +7,7 @@ class Omero52 < Formula
   sha256 '81f0d29e6ec2f26cb6e4bba6c0a9e62c18567b9a3cd8050ac11a4b4fc4e7ed7e'
 
   option 'with-cpp', 'Build OmeroCpp libraries.'
+  option 'with-ice36', 'Use Ice 3.6.'
 
   depends_on :python
   depends_on :fortran
@@ -14,7 +15,8 @@ class Omero52 < Formula
   depends_on 'pkg-config' => :build
   depends_on 'hdf5'
   depends_on 'jpeg'
-  depends_on 'zeroc-ice35' => 'with-python'
+  depends_on 'zeroc-ice35' => 'with-python' if build.without? 'ice36'
+  depends_on 'ice' if build.with? 'ice36'
   depends_on 'mplayer' => :recommended
   depends_on 'nginx' => :optional
   depends_on 'cmake' if build.with? 'cpp'
@@ -27,7 +29,9 @@ class Omero52 < Formula
     # Create config file to specify dist.dir (see #9203)
     (Pathname.pwd/"etc/local.properties").write config_file
 
-    ENV['SLICEPATH'] = "#{HOMEBREW_PREFIX}/share/Ice-3.5/slice"
+    if build.without? 'ice36'
+      ENV['SLICEPATH'] = "#{HOMEBREW_PREFIX}/share/Ice-3.5/slice"
+    end
     args = ["./build.py", "-Dice.home=#{ice_prefix}"]
     if build.with? 'cpp'
       args << 'build-all'
@@ -51,7 +55,11 @@ class Omero52 < Formula
   end
 
   def ice_prefix
-    Formula['zeroc-ice35'].opt_prefix
+    if build.without? 'ice36'
+      Formula['zeroc-ice35'].opt_prefix
+    else
+      Formula['ice'].opt_prefix
+    end
   end
 
   def caveats;


### PR DESCRIPTION
Bump version to 5.2.8 and add support for ice 3.6
issue with the zeroc-ice35 formula
see https://github.com/ome/homebrew-alt/pull/124 https://github.com/ome/homebrew-alt/pull/123

Allow  the OMERO 5.2 formula to be installed with Ice 3.6 
Add a `--with-ice36` option and update the pulled Ice dependency as well as the build formula.

This can be tested locally by running

```
brew install Formula/omero52.rb --with-ice36
```