### PR TITLE
Bio-Formats: use local Maven repository that can be sandboxed

### DIFF
--- a/Formula/bioformats55.rb
+++ b/Formula/bioformats55.rb
@@ -8,7 +8,8 @@ class Bioformats55 < Formula
 
   def install
     # Build libraries
-    args = ["ant", "clean", "tools"]
+    args = ["ant", "clean", "tools", "-Dmaven.repo.local",
+            "#{buildpath}/.m2/repository"]
     system *args
 
     # Remove Windows files


### PR DESCRIPTION
Following a recent change in upstream Homebrew, all formulas in external taps
are sandboxed and cannot write under `$HOME`. This affects our formulas
using the default Maven `.m2` directory. Similarly to other formulas in
homebrew-core (lumo.rb), this commit uses a local Maven repository using the
temporary `#{buildpath}` path.