### PR TITLE
OMERO: Use local Maven repository that can be sandboxed

### DIFF
--- a/Formula/omero53.rb
+++ b/Formula/omero53.rb
@@ -50,6 +50,7 @@ class Omero53 < Formula
 
   def config_file
     <<-EOF.undent
+      local-maven2-dir=#{buildpath}/.m2/repository
       dist.dir=#{prefix}
     EOF
   end


### PR DESCRIPTION
Companion to https://github.com/ome/homebrew-alt/pull/135 for OMERO

Following a recent change in upstream Homebrew, all formulas in external taps
are sandboxed and cannot write under `$HOME`. This affects our formulas
using the default Maven `.m2` directory. Similarly to other formulas in
homebrew-core (lumo.rb), this commit uses a local Maven repository using the
temporary `#{buildpath}` path.