### PR TITLE
Add Bio-Formats 5.6.0 formula

### DIFF
--- a/Aliases/bioformats
+++ b/Aliases/bioformats
@@ -1,1 +1,0 @@
-../Formula/bioformats55.rb

--- a/Aliases/bioformats@5.6
+++ b/Aliases/bioformats@5.6
@@ -1,0 +1,1 @@
+../Formula/bioformats.rb

--- a/Formula/bioformats.rb
+++ b/Formula/bioformats.rb
@@ -1,0 +1,32 @@
+class Bioformats < Formula
+  desc "Library for reading proprietary image file formats"
+  homepage "http://www.openmicroscopy.org/site/products/bio-formats"
+  url "http://downloads.openmicroscopy.org/bio-formats/5.6.0/artifacts/bioformats-5.6.0.zip"
+  sha256 "8a4ffa70850ce88511ac41d00800a6fb0180b126b15da41ad612f7f7a25fb023"
+
+  depends_on "ant" => :build
+
+  def install
+    # Build libraries
+    args = ["ant", "clean", "tools", "-Dmaven.repo.local",
+            "#{buildpath}/.m2/repository"]
+    system *args
+
+    # Remove Windows files
+    rm Dir["tools/*.bat"]
+
+    # Copy artifacts
+    libexec.install "artifacts/bioformats_package.jar"
+
+    # Copy command line-tools
+    libexec.install Dir["tools/*"]
+
+    %w[bfconvert domainlist formatlist ijview mkfake omeul showinf tiffcomment xmlindent xmlvalid].each do |fn|
+      bin.install_symlink libexec/fn
+    end
+  end
+  test do
+    system "showinf", "-version"
+    system "bfconvert", "-version"
+  end
+end


### PR DESCRIPTION
See https://trello.com/c/5za5Sz7B/24-open-a-pr-to-bump-the-homebrew-formula

This PR 

- updates our latest bioformats formula link and hashes to consume 5.6.0
- updates our versioned formula strategy to match the one used upstream (see https://github.com/Homebrew/homebrew-core/blob/master/Aliases/postgresql@9.6, https://github.com/Homebrew/homebrew-core/blob/master/Formula/postgresql@9.5.rb, https://github.com/Homebrew/homebrew-core/blob/master/Formula/postgresql@9.4.rb):
   - `bioformats.rb` is moved under Formula instead of Aliases
   - old versioned formulas are stored using the `@` semantics i.e `Formulas/bioformats@5.5.rb`
   - the latest versioned formula will be stored under `Aliases` i.e `Aliases/bioformats@5.6`

With this PR, `brew install/update bioformats` should properly track the latest release while older versions can be installed using `brew install bioformats@x.y`. See https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-homebrew/ for the execution of this change.